### PR TITLE
📝 Update docs badge link to Wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/store2be/redux-belt.svg?branch=master)](https://travis-ci.org/store2be/redux-belt)
 [![codecov](https://codecov.io/gh/store2be/redux-belt/branch/master/graph/badge.svg)](https://codecov.io/gh/store2be/redux-belt)
 [![Code Climate](https://codeclimate.com/github/store2be/redux-belt.svg)](https://codeclimate.com/github/store2be/redux-belt)
-[![Inline docs](http://inch-ci.org/github/store2be/redux-belt.svg?branch=add-inch-ci)](http://inch-ci.org/github/store2be/redux-belt)
+[![Inline docs](http://inch-ci.org/github/store2be/redux-belt.svg?branch=master)](https://github.com/store2be/redux-belt/wiki)
 [![npm version](https://img.shields.io/npm/v/redux-belt.svg?style=flat-square)](https://www.npmjs.com/package/redux-belt)
 [![npm version](https://img.shields.io/npm/dm/redux-belt.svg?style=flat-square)](https://www.npmjs.com/package/redux-belt)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/store2be/redux-belt/blob/master/CONTRIBUTING.md)
@@ -21,6 +21,8 @@ Here are the design-defining constraints that `redux-belt` introduces:
 
 You can find [a comparison with similar existing projects in our wiki](https://github.com/store2be/redux-belt/wiki/Comparison-to-similar-projects).
 Visit the [redux-belt homepage](https://store2be.github.io/redux-belt/).
+
+[Our documentation is tested by InchCI](http://inch-ci.org/github/store2be/redux-belt)
 
 ## Installation
 


### PR DESCRIPTION
Because one wants to get to the docs, when clicking
on docs. But we still have the link to InchCI in plain
text below.